### PR TITLE
Add ProcessAccess rules

### DIFF
--- a/sysmonconfig-export.xml
+++ b/sysmonconfig-export.xml
@@ -282,8 +282,14 @@
 
 	<!--SYSMON EVENT ID 10 : INTER-PROCESS ACCESS-->
 		<!--DATA: UtcTime, SourceProcessGuid, SourceProcessId, SourceThreadId, SourceImage, TargetProcessGuid, TargetProcessId, TargetImage, GrantedAccess, CallTrace-->
+		<ProcessAccess onmatch="exclude">
+		<!--COMMENT:	Log the hash dump operation from lsass. Tested by mimikatz and wce.-->
+			<GrantedAccess condition="is">0x1400</GrantedAccess>
+			<GrantedAccess condition="is">0x1000</GrantedAccess>
+		</ProcessAccess>
 		<ProcessAccess onmatch="include">
 		<!--COMMENT:	Monitor for processes accessing other process' memory. This can be valuable, but can cause a huge number of events.-->
+			<TargetImage condition="is">C:\Windows\system32\lsass.exe</TargetImage>
 		</ProcessAccess>
 
 	<!--SYSMON EVENT ID 11 : FILE CREATED-->

--- a/sysmonconfig-export.xml
+++ b/sysmonconfig-export.xml
@@ -282,15 +282,22 @@
 
 	<!--SYSMON EVENT ID 10 : INTER-PROCESS ACCESS-->
 		<!--DATA: UtcTime, SourceProcessGuid, SourceProcessId, SourceThreadId, SourceImage, TargetProcessGuid, TargetProcessId, TargetImage, GrantedAccess, CallTrace-->
-		<ProcessAccess onmatch="exclude">
-		<!--COMMENT:	Log the hash dump operation from lsass. Tested by mimikatz and wce.-->
-			<GrantedAccess condition="is">0x1400</GrantedAccess>
-			<GrantedAccess condition="is">0x1000</GrantedAccess>
-		</ProcessAccess>
+<!-- 		<ProcessAccess onmatch="include">
+		COMMENT:	Monitor for processes accessing other process' memory. This can be valuable, but can cause a huge number of events.
+		</ProcessAccess> -->
 		<ProcessAccess onmatch="include">
-		<!--COMMENT:	Monitor for processes accessing other process' memory. This can be valuable, but can cause a huge number of events.-->
 			<TargetImage condition="is">C:\Windows\system32\lsass.exe</TargetImage>
 		</ProcessAccess>
+
+		<ProcessAccess onmatch="exclude">
+		<!--COMMENT:	this will catch the dump hash operation from lsass. tested by mimikatz,wce-->
+			<GrantedAccess condition="is">0x1400</GrantedAccess>
+			<GrantedAccess condition="is">0x1000</GrantedAccess>
+			<SourceImage condition="is">C:\Windows\System32\wbem\WmiPrvSE.exe</SourceImage>
+			
+		</ProcessAccess>
+
+
 
 	<!--SYSMON EVENT ID 11 : FILE CREATED-->
 		<!--DATA: UtcTime, ProcessGuid, ProcessId, Image, TargetFilename, CreationUtcTime-->

--- a/sysmonconfig-export.xml
+++ b/sysmonconfig-export.xml
@@ -160,7 +160,7 @@
 		</FileCreateTime>
 
 	<!--SYSMON EVENT ID 3 : NETWORK CONNECTION INITIATED-->
-		<!--DATA: UtcTime, ProcessGuid, ProcessId, Image, User, Protocol, Initiated, SourceIsIpv6, SourceIp, SourceHostname, SourcePort, SourcePortName, DestinationIsIpV6, DestinationIP, DestinationHostname, DestinationPort, DestinationPortName-->
+		<!--DATA: UtcTime, ProcessGuid, ProcessId, Image, User, Protocol, Initiated, SourceIsIpv6, SourceIp, SourceHostname, SourcePort, SourcePortName, DestinationIsIpV6, DestinationIp, DestinationHostname, DestinationPort, DestinationPortName-->
 		<NetworkConnect onmatch="include">
 		<!--COMMENT:	Takes a very conservative approach to network logging, limit to extremely high-signal events.-->
 		<!--TECHNICAL:	For the DestinationHostname, Sysmon uses the GetNameInfo API, which may not always have the information or may be a CDN. Using that field is best-effort only.-->


### PR DESCRIPTION
Add ProcessAccess rules,log the hash dump operation from lsass.exe.Tested by mimikatz v2.1.1 and wce . 
This is GrantedAccess of the tools when dump hash below:
**wce.exe**
`GrantedAccess: 0x1fffff`
**mimikatz.exe**
`GrantedAccess of: 0x1010, 0x1410, 0x143A`

Reference link:
http://www.freebuf.com/sectool/122779.html
https://msdn.microsoft.com/en-us/library/windows/desktop/ms684880
http://security-research.dyndns.org/pub/slides/FIRST2017/FIRST-2017_Tom-Ueltschi_Sysmon_FINAL.pdf