### PR TITLE
Blizzard Agent

### DIFF
--- a/sysmonconfig-export.xml
+++ b/sysmonconfig-export.xml
@@ -363,6 +363,7 @@
 			<Image condition="end with">AppData\Roaming\Dropbox\bin\Dropbox.exe</Image> <!--Dropbox-->
 			<Image condition="image">g2ax_comm_expert.exe</Image> <!--GoToMeeting-->
 			<Image condition="image">g2mcomm.exe</Image> <!--GoToMeeting-->
+			<Image condition="image">Agent.exe</Image> <!--Blizzard App Agent-->
 			<!--SECTION: Microsoft-->
 			<Image condition="image">OneDrive.exe</Image> <!--Microsoft:OneDrive-->
 			<Image condition="image">OneDriveStandaloneUpdater.exe</Image> <!--Microsoft:OneDrive-->


### PR DESCRIPTION
Yes it's called Agent.exe, yes it's in ProgramData
Yes it's in a subfolder with a build number like `Agent.6082` 
so it's nearly impossible to exclude right. Mostly I'm making this
pull request as a way to ping the community as a way to fix this.