### PR TITLE
FileCreate: match ".dmp" files

### DIFF
--- a/sysmonconfig-export.xml
+++ b/sysmonconfig-export.xml
@@ -466,6 +466,7 @@
 			<TargetFilename condition="end with">.chm</TargetFilename>
 			<TargetFilename condition="end with">.cmd</TargetFilename> <!--Batch scripting: Batch scripts can also use the .cmd extension | Credit: @mmazanec -->
 			<TargetFilename condition="end with">.cmdline</TargetFilename> <!--Microsoft:dotNet: Executed by cvtres.exe-->
+			<TargetFilename condition="end with">.dmp</TargetFilename> <!--Process dumps [ (fr) http://blog.gentilkiwi.com/securite/mimikatz/minidump ] -->
 			<TargetFilename condition="end with">.docm</TargetFilename> <!--Microsoft:Office:Word: Macro-->
 			<TargetFilename condition="end with">.exe</TargetFilename> <!--Executable-->
 			<TargetFilename condition="end with">.jar</TargetFilename> <!--Java applets-->


### PR DESCRIPTION
According to [gentilkiwi's blog post](http://blog.gentilkiwi.com/securite/mimikatz/minidump) (in French, sorry), it is possible to dump `lsass.exe` directly from the Task Manager, without using `procdump` or any similar tool. Mimikatz can then be used on this dump as usual.

What's interesting is you cannot specify the name of the dump file, it is always of the form `[processname].DMP`.

I believe monitoring the creation of files with extension `.dmp` could help catch attackers trying to use this technique to steal credentials.