### PR TITLE
Added named pipe used by Cobalt Strike

### DIFF
--- a/sysmonconfig-export.xml
+++ b/sysmonconfig-export.xml
@@ -818,12 +818,22 @@
 
 		<!--ADDITIONAL REFERENCE: [ https://www.cobaltstrike.com/help-smb-beacon ] -->
 		<!--ADDITIONAL REFERENCE: [ https://blog.cobaltstrike.com/2015/10/07/named-pipe-pivoting/ ] -->
+		<!--ADDITIONAL REFERENCE: [ https://blog.cobaltstrike.com/2021/02/09/learn-pipe-fitting-for-all-of-your-offense-projects/ ] -->
+	
 
 		<!--DATA: UtcTime, ProcessGuid, ProcessId, PipeName, Image-->
 	<RuleGroup name="" groupRelation="or">
 		<PipeEvent onmatch="include">
-			<!--NOTE: Using incide with no rules means nothing in this section will be logged-->
-		</PipeEvent>
+        <Rule groupRelation="and">
+        <PipeName condition="begin with">\msse-</PipeName>        <!-- default cobalt strike pipe name-->
+        <PipeName condition="end with">-server</PipeName>        <!-- default cobalt strike pipe name-->
+        </Rule>
+        <PipeName condition="begin with">\msagent_</PipeName>        <!-- default cobalt strike pipe name-->
+        <PipeName condition="begin with">\postex_</PipeName>        <!-- default cobalt strike pipe name-->
+        <PipeName condition="begin with">\postex_ssh_</PipeName>        <!-- default cobalt strike pipe name-->
+        <PipeName condition="begin with">\status_</PipeName>        <!-- default cobalt strike pipe name-->
+      </PipeEvent>
+
 	</RuleGroup>
 
 	<!--SYSMON EVENT ID 19 & 20 & 21 : WMI EVENT MONITORING [WmiEvent]-->


### PR DESCRIPTION
Hi,
According Cobalt Strike documentation (https://blog.cobaltstrike.com/2021/02/09/learn-pipe-fitting-for-all-of-your-offense-projects/) and some test I suggest to add a named pipe used by Cobalt Strike.

Take into account widely Cobalt Strike is used today, adding this could be useful for all of us.
Some reports about Cobalt Strike from 2020:
https://content.fireeye.com/m-trends/rpt-m-trends-2021 (page 26)
https://redcanary.com/threat-detection-report/ (page 84)

I wanted to point out that the basic config is from Olaf Hartong (https://github.com/olafhartong/sysmon-modular/blob/master/17_18_pipe_event/include_cobaltstrike.xml)
I added extra pipe and fixed one bug, extra info in PR:
https://github.com/olafhartong/sysmon-modular/pull/97