### PR TITLE
Add pwsh.exe to list of suspicious Windows tools

### DIFF
--- a/sysmonconfig-export.xml
+++ b/sysmonconfig-export.xml
@@ -303,6 +303,7 @@
 			<Image condition="image">nslookup.exe</Image> <!--Windows: Retrieve data over DNS -->
 			<Image condition="image">powershell.exe</Image> <!--Windows: PowerShell interface-->
 			<Image condition="image">powershell_ise.exe</Image> <!--Windows: PowerShell interface-->
+			<Image condition="image">pwsh.exe</Image> <!--Windows: PowerShell Version 6 and above interface-->
 			<Image condition="image">qprocess.exe</Image> <!--Windows: [ https://www.first.org/resources/papers/conf2017/APT-Log-Analysis-Tracking-Attack-Tools-by-Audit-Policy-and-Sysmon.pdf ] -->
 			<Image condition="image">qwinsta.exe</Image> <!--Windows: Query remote sessions | Credit @ion-storm -->
 			<Image condition="image">qwinsta.exe</Image> <!--Windows: Remotely query login sessions on a server or workstation | Credit @ion-storm -->


### PR DESCRIPTION
PowerShell versions 6 and above use the executable `pwsh.exe` instead of `powershell.exe`:

- [First introduced in PowerShell 6](https://learn.microsoft.com/en-us/previous-versions/powershell/scripting/whats-new/breaking-changes-ps6?view=powershell-6#rename-powershellexe-to-pwshexe-5101)
- [Also used in PowerShell 7](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/differences-from-windows-powershell?view=powershell-7.3#powershell-executable-changes)

`pwsh.exe` doesn't come installed by default like `powershell.exe` but I thought it may still be worth adding to the list of "Suspicious Windows tools" in the NetworkConnect rule group.